### PR TITLE
E2421 Reimplement impersonating users

### DIFF
--- a/app/controllers/api/v1/impersonate_controller.rb
+++ b/app/controllers/api/v1/impersonate_controller.rb
@@ -1,14 +1,37 @@
 class Api::V1::ImpersonateController < ApplicationController
-  # before_action :check_if_input_is_valid
 
+  # Fetches users to impersonate whose name match the passed parameter
   def get_users_list
     users = current_user.get_available_users(params[:user_name])
     render json: { message: "Successfully Fetched User List!", userList:users, success:true }, status: :ok
   end
 
-  def impersonate
-  #   Logic For Impersonate
-  render json: { message: "Successfully Impersonated User!", newjwt:"token" }, status: :ok
+  def check_if_user_impersonateable?
+    impersonate_user = User.find_by(id: params[:impersonate_id])
+    if impersonate_user
+      return current_user.can_impersonate? impersonate_user
+    end
+    false
   end
 
+  # Impersonates a new user and returns new jwt token
+  def impersonate
+    unless params[:impersonate_id].present?
+      render json: { error: "impersonate_id is required", success:false }, status: :unprocessable_entity
+      return
+    end
+
+    if check_if_user_impersonateable?
+      impersonate_user = User.find_by(id: params[:impersonate_id])
+
+      payload = { id: impersonate_user.id, name: impersonate_user.name, full_name: impersonate_user.full_name, role: impersonate_user.role.name,
+                  institution_id: impersonate_user.institution.id, impersonated:true, original_user: current_user }
+      impersonate_user_token = JsonWebToken.encode(payload, 24.hours.from_now)
+
+      render json: { message: "Successfully Impersonated #{impersonate_user.name}!", token:impersonate_user_token, success:true }, status: :ok
+
+    else
+      render json: { error: "You do not have permission to impersonate this user", success:false }, status: :forbidden
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -125,7 +125,7 @@ class User < ApplicationRecord
     return true if p == self.role
     return false if p.super_administrator?
     recursively_parent_of(p)
-  end
+  end
 
   # This will override the default as_json method in the ApplicationRecord class and specify
   # that only the id, name, and email attributes should be included when a User object is serialized.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,7 +73,7 @@ Rails.application.routes.draw do
       end
 
       resources :impersonate do
-        get 'user/:user_name', on: :collection, to: 'impersonate#get_users_list'
+        get ':user_name', on: :collection, to: 'impersonate#get_users_list'
         post '', on: :collection, to: 'impersonate#impersonate'
       end
 


### PR DESCRIPTION
# Problem Statement:
The objective is to reimplement the backend code for the impersonation feature in the new implementation of Expertiza. The current implementation relies on sessions, which won't be compatible with the new implementation using JWT tokens for authentication and returning JSON responses. The challenge lies in transitioning the logic from session-based management to JWT-based authentication while maintaining the functionality of impersonating users. The reimplementation involves planning how the backend will communicate with the frontend, potentially requiring changes in existing or new files beyond the impersonate_controller.rb.

# Wiki Page Link:
[Wiki Page - E2421](https://wiki.expertiza.ncsu.edu/index.php?title=CSC/ECE_517_Spring_2024_-_E2421._Reimplement_impersonating_users_(within_impersonate_controller.rb))