### PR TITLE
E2473. Reimplement sign_up_topic.rb as project_topic.rb

### DIFF
--- a/app/models/project_topic.rb
+++ b/app/models/project_topic.rb
@@ -1,4 +1,4 @@
-class SignUpTopic < ApplicationRecord
+class ProjectTopic < ApplicationRecord
   has_many :signed_up_teams, foreign_key: 'topic_id', dependent: :destroy
   has_many :teams, through: :signed_up_teams # list all teams choose this topic, no matter in waitlist or not
   has_many :assignment_questionnaires, class_name: 'AssignmentQuestionnaire', foreign_key: 'topic_id', dependent: :destroy


### PR DESCRIPTION
**Project Overview:**

The project involves reimplementing sign_up_topic.rb from the Expertiza repository. This class manages topics within an assignment by handling slot availability, team signups, and waitlist management. It tracks topic details, assigns teams to open slots, imports topics for assignments, and handles new topics from suggestions. Additionally, it manages staggered deadlines and team due dates. The task is to redesign sign_up_topic in the reimplementation_backend repository, ensuring it adheres to Rails design principles and follows the DRY principle.