### PR TITLE
Fix Danger bot failure by fetching full Git history in CI

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -21,5 +21,5 @@ jobs:
 
       - name: Run Danger
         env:
-          DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
         run: bundle exec danger --verbose

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -21,5 +21,5 @@ jobs:
 
       - name: Run Danger
         env:
-          DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+          DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bundle exec danger --verbose


### PR DESCRIPTION
This PR fixes the Danger bot workflow by updating the actions/checkout step to set fetch-depth: 0.

This ensures the full commit history is available, allowing Danger to find the base commit for comparison.

Without this change, Danger fails with a missing commit error on all PRs due to shallow clone behavior.