### PR TITLE
Skip danger.yml workflow for forked PRs using conditional check

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -4,10 +4,13 @@ on:
     types: [opened, synchronize, reopened]
 jobs:
   danger:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This PR prevents the danger.yml workflow from running on pull requests originating from forks. Forked PRs lack access to repository secrets and can fail with errors related to missing commits or permission issues.

Why this change?
The danger bot was failing for all forked PRs due to GitHub security limitations. Since we already have danger_target.yml to handle forked PRs, this change ensures that danger.yml only runs on internal PRs.

A conditional check was added to the danger.yml job.