### PR TITLE
Unified Login Response

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ gem 'find_with_order'
 # For handling zip file uploads and extraction
 gem 'rubyzip'
 
+gem 'openid_connect'
 
 group :development, :test do
   gem 'debug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,11 +79,14 @@ GEM
       uri (>= 0.13.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    aes_key_wrap (1.1.0)
     ast (2.4.3)
+    attr_required (1.0.2)
     base64 (0.3.0)
     bcrypt (3.1.20)
     benchmark (0.4.1)
     bigdecimal (3.2.3)
+    bindata (2.5.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
     builder (3.3.0)
@@ -134,6 +137,8 @@ GEM
     docile (1.4.1)
     domain_name (0.6.20240107)
     drb (2.2.3)
+    email_validator (2.2.4)
+      activemodel
     erb (5.0.2)
     erubi (1.13.1)
     factory_bot (6.5.5)
@@ -147,6 +152,8 @@ GEM
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
+    faraday-follow_redirects (0.5.0)
+      faraday (>= 1, < 3)
     faraday-http-cache (2.5.1)
       faraday (>= 0.8)
     faraday-net_http (3.4.1)
@@ -174,6 +181,13 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.15.0)
+    json-jwt (1.17.0)
+      activesupport (>= 4.2)
+      aes_key_wrap
+      base64
+      bindata
+      faraday (~> 2.0)
+      faraday-follow_redirects
     json-schema (5.2.2)
       addressable (~> 2.8)
       bigdecimal (~> 3.1)
@@ -238,6 +252,19 @@ GEM
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     open4 (1.3.4)
+    openid_connect (2.3.1)
+      activemodel
+      attr_required (>= 1.0.0)
+      email_validator
+      faraday (~> 2.0)
+      faraday-follow_redirects
+      json-jwt (>= 1.16)
+      mail
+      rack-oauth2 (~> 2.2)
+      swd (~> 2.0)
+      tzinfo
+      validate_url
+      webfinger (~> 2.0)
     ostruct (0.6.3)
     parallel (1.27.0)
     parser (3.3.9.0)
@@ -260,6 +287,13 @@ GEM
     rack-cors (3.0.0)
       logger
       rack (>= 3.0.14)
+    rack-oauth2 (2.3.0)
+      activesupport
+      attr_required
+      faraday (~> 2.0)
+      faraday-follow_redirects
+      json-jwt (>= 1.11.0)
+      rack (>= 2.1.0)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -374,6 +408,11 @@ GEM
     sqlite3 (1.7.3)
       mini_portile2 (~> 2.8.0)
     stringio (3.1.7)
+    swd (2.0.3)
+      activesupport (>= 3)
+      attr_required (>= 0.0.5)
+      faraday (~> 2.0)
+      faraday-follow_redirects
     sync (0.5.0)
     term-ansicolor (1.11.3)
       tins (~> 1)
@@ -395,6 +434,13 @@ GEM
     unicode-emoji (4.1.0)
     uri (1.0.3)
     useragent (0.16.11)
+    validate_url (1.0.15)
+      activemodel (>= 3.0.0)
+      public_suffix
+    webfinger (2.1.3)
+      activesupport
+      faraday (~> 2.0)
+      faraday-follow_redirects
     websocket-driver (0.8.0)
       base64
       websocket-extensions (>= 0.1.0)
@@ -435,6 +481,7 @@ DEPENDENCIES
   mutex_m
   mysql2 (~> 0.5.7)
   observer
+  openid_connect
   ostruct
   psych (~> 5.2)
   puma (~> 6.4)

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -1,6 +1,3 @@
-# app/controllers/authentication_controller.rb
-require 'json_web_token'
-
 class AuthenticationController < ApplicationController
   skip_before_action :authenticate_request!
 
@@ -8,9 +5,7 @@ class AuthenticationController < ApplicationController
   def login
     user = User.find_by(name: params[:user_name]) || User.find_by(email: params[:user_name])
     if user&.authenticate(params[:password])
-      payload = { id: user.id, name: user.name, full_name: user.full_name, role: user.role.name,
-                  institution_id: user.institution.id }
-      token = JsonWebToken.encode(payload, 24.hours.from_now)
+      token = user.generate_jwt
       render json: { token: }, status: :ok
     else
       render json: { error: 'Invalid username / password' }, status: :unauthorized

--- a/app/controllers/oidc_login_controller.rb
+++ b/app/controllers/oidc_login_controller.rb
@@ -87,42 +87,6 @@ class OidcLoginController < ApplicationController
     render json: { error: "Token verification failed: #{e.message}" }, status: :unauthorized
   end
 
-  # Temporary: handle IdP redirect directly instead of via frontend
-  def callback_redirect
-    auth_request = AuthRequest
-                     .where("created_at > ?", 5.minutes.ago)
-                     .find_by!(state: params[:state])
-    auth_request.destroy!
-
-    provider = OidcConfig.find(auth_request.provider)
-    client   = build_client(provider)
-
-    client.authorization_code = params[:code]
-    access_token = client.access_token!(
-      code_verifier: auth_request.code_verifier
-    )
-
-    discovery = discover(provider)
-    id_token  = OpenIDConnect::ResponseObject::IdToken.decode(
-      access_token.id_token,
-      discovery.jwks
-    )
-    id_token.verify!(
-      issuer:    discovery.issuer,
-      client_id: provider["client_id"],
-      nonce:     auth_request.nonce
-    )
-
-    email = id_token.raw_attributes["email"]
-    user  = User.find_by(email: email)
-
-    if user
-      render json: { user: user.as_json, session_token: issue_jwt(user) }
-    else
-      render json: { error: "No account found for #{email}", email: email }, status: :not_found
-    end
-  end
-
   private
 
   def build_client(provider)

--- a/app/controllers/oidc_login_controller.rb
+++ b/app/controllers/oidc_login_controller.rb
@@ -1,5 +1,3 @@
-require 'json_web_token'
-
 class OidcLoginController < ApplicationController
   skip_before_action :authenticate_request!
 
@@ -75,7 +73,7 @@ class OidcLoginController < ApplicationController
     user  = User.find_by(email: email)
 
     if user
-      token = issue_jwt(user)
+      token = user.generate_jwt
       render json: { token: }, status: :ok
     else
       render json: { error: "No account found for #{email}" }, status: :not_found
@@ -106,17 +104,5 @@ class OidcLoginController < ApplicationController
     @discoveries ||= {}
     @discoveries[provider["issuer"]] ||=
       OpenIDConnect::Discovery::Provider::Config.discover!(provider["issuer"])
-  end
-
-  # Note this is the same as authentication_controller, could combine into the user model
-  def issue_jwt(user)
-    payload = {
-      id: user.id,
-      name: user.name,
-      full_name: user.full_name,
-      role: user.role.name,
-      institution_id: user.institution.id
-    }
-    JsonWebToken.encode(payload, 24.hours.from_now)
   end
 end

--- a/app/controllers/oidc_login_controller.rb
+++ b/app/controllers/oidc_login_controller.rb
@@ -76,7 +76,7 @@ class OidcLoginController < ApplicationController
 
     if user
       token = issue_jwt(user)
-      render json: { user: user.as_json, session_token: token }
+      render json: { token: }, status: :ok
     else
       render json: { error: "No account found for #{email}" }, status: :not_found
     end

--- a/app/controllers/oidc_login_controller.rb
+++ b/app/controllers/oidc_login_controller.rb
@@ -1,0 +1,158 @@
+require 'json_web_token'
+
+class OidcLoginController < ApplicationController
+  skip_before_action :authenticate_request!
+
+  # GET /auth/providers
+  def providers
+    render json: OidcConfig.public_list
+  end
+
+  # POST /auth/client-select
+  def client_select
+    provider = OidcConfig.find(params[:provider])
+    client   = build_client(provider)
+
+    # Generate state, nonce, and PKCE
+    state         = SecureRandom.hex(32)
+    nonce         = SecureRandom.hex(32)
+    code_verifier = SecureRandom.urlsafe_base64(64)
+    code_challenge = Base64.urlsafe_encode64(
+      Digest::SHA256.digest(code_verifier), padding: false
+    )
+
+    # Store in DB for callback verification
+    AuthRequest.create!(
+      state:         state,
+      nonce:         nonce,
+      code_verifier: code_verifier,
+      provider:      params[:provider]
+    )
+
+    # Build the authorization URL
+    authorization_uri = client.authorization_uri(
+      scope:                [:openid, :email, :profile],
+      state:                state,
+      nonce:                nonce,
+      code_challenge:       code_challenge,
+      code_challenge_method: "S256"
+    )
+
+    render json: { redirect_uri: authorization_uri }
+  end
+
+  # POST /auth/callback
+  def callback
+    # Look up and consume the auth request
+    auth_request = AuthRequest
+                     .where("created_at > ?", 5.minutes.ago)
+                     .find_by!(state: params[:state])
+    auth_request.destroy!
+
+    provider = OidcConfig.find(auth_request.provider)
+    client   = build_client(provider)
+
+    # Exchange authorization code for tokens
+    client.authorization_code = params[:code]
+    access_token = client.access_token!(
+      code_verifier: auth_request.code_verifier
+    )
+
+    # Decode and verify the ID token
+    discovery = discover(provider)
+    id_token  = OpenIDConnect::ResponseObject::IdToken.decode(
+      access_token.id_token,
+      discovery.jwks
+    )
+    id_token.verify!(
+      issuer:    discovery.issuer,
+      client_id: provider["client_id"],
+      nonce:     auth_request.nonce
+    )
+
+    # Match to existing user by email
+    email = id_token.raw_attributes["email"]
+    user  = User.find_by(email: email)
+
+    if user
+      token = issue_jwt(user)
+      render json: { user: user.as_json, session_token: token }
+    else
+      render json: { error: "No account found for #{email}" }, status: :not_found
+    end
+
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: "Invalid or expired login request" }, status: :unprocessable_entity
+  rescue OpenIDConnect::ResponseObject::IdToken::InvalidToken => e
+    render json: { error: "Token verification failed: #{e.message}" }, status: :unauthorized
+  end
+
+  # Temporary: handle IdP redirect directly instead of via frontend
+  def callback_redirect
+    auth_request = AuthRequest
+                     .where("created_at > ?", 5.minutes.ago)
+                     .find_by!(state: params[:state])
+    auth_request.destroy!
+
+    provider = OidcConfig.find(auth_request.provider)
+    client   = build_client(provider)
+
+    client.authorization_code = params[:code]
+    access_token = client.access_token!(
+      code_verifier: auth_request.code_verifier
+    )
+
+    discovery = discover(provider)
+    id_token  = OpenIDConnect::ResponseObject::IdToken.decode(
+      access_token.id_token,
+      discovery.jwks
+    )
+    id_token.verify!(
+      issuer:    discovery.issuer,
+      client_id: provider["client_id"],
+      nonce:     auth_request.nonce
+    )
+
+    email = id_token.raw_attributes["email"]
+    user  = User.find_by(email: email)
+
+    if user
+      render json: { user: user.as_json, session_token: issue_jwt(user) }
+    else
+      render json: { error: "No account found for #{email}", email: email }, status: :not_found
+    end
+  end
+
+  private
+
+  def build_client(provider)
+    discovery = discover(provider)
+    OpenIDConnect::Client.new(
+      identifier:             provider["client_id"],
+      secret:                 provider["client_secret"],
+      redirect_uri:           provider["redirect_uri"],
+      authorization_endpoint: discovery.authorization_endpoint,
+      token_endpoint:         discovery.token_endpoint,
+      userinfo_endpoint:      discovery.userinfo_endpoint
+    )
+  end
+
+  def discover(provider)
+    # Cache discovery per provider at app level
+    @discoveries ||= {}
+    @discoveries[provider["issuer"]] ||=
+      OpenIDConnect::Discovery::Provider::Config.discover!(provider["issuer"])
+  end
+
+  # Note this is the same as authentication_controller, could combine into the user model
+  def issue_jwt(user)
+    payload = {
+      id: user.id,
+      name: user.name,
+      full_name: user.full_name,
+      role: user.role.name,
+      institution_id: user.institution.id
+    }
+    JsonWebToken.encode(payload, 24.hours.from_now)
+  end
+end

--- a/app/controllers/oidc_login_controller.rb
+++ b/app/controllers/oidc_login_controller.rb
@@ -102,7 +102,7 @@ class OidcLoginController < ApplicationController
   end
 
   def discover(provider)
-    # Cache discovery per provider at app level
+    # Avoid duplicate discovery calls within the same request
     @discoveries ||= {}
     @discoveries[provider["issuer"]] ||=
       OpenIDConnect::Discovery::Provider::Config.discover!(provider["issuer"])

--- a/app/models/auth_request.rb
+++ b/app/models/auth_request.rb
@@ -1,0 +1,2 @@
+class AuthRequest < ApplicationRecord
+end

--- a/app/models/oidc_config.rb
+++ b/app/models/oidc_config.rb
@@ -1,0 +1,48 @@
+class OidcConfig
+  class ProviderNotFound < StandardError; end
+
+  CONFIG_FILE = Rails.root.join("config", "oidc_providers.yml").freeze
+
+  def self.providers
+    @providers ||= begin
+                     yaml = ERB.new(File.read(CONFIG_FILE)).result
+                     parsed = YAML.safe_load(yaml, permitted_classes: [], aliases: true)
+                     providers_config = parsed&.fetch("providers", {})
+                     validate!(providers_config || {})
+                   end
+  end
+
+  def self.find(provider_key)
+    providers.fetch(provider_key) do
+      raise ProviderNotFound, "Unknown OIDC provider: #{provider_key}"
+    end
+  end
+
+  def self.public_list
+    providers.map { |key, cfg| provider_summary(key, cfg) }
+  end
+
+  def self.reload!
+    @providers = nil
+  end
+
+  private
+
+  REQUIRED_KEYS = %w[display_name issuer client_id client_secret redirect_uri scopes].freeze
+
+  def self.validate!(providers)
+    return {} if providers.blank?
+
+    providers.each do |key, cfg|
+      missing = REQUIRED_KEYS.select { |k| cfg[k].blank? }
+      if missing.any?
+        raise "OIDC provider '#{key}' is missing required config: #{missing.join(', ')}"
+      end
+    end
+    providers
+  end
+
+  def self.provider_summary(key, cfg)
+    { id: key, name: cfg["display_name"] }
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'json_web_token'
 
 class User < ApplicationRecord
   has_secure_password
@@ -149,8 +150,15 @@ class User < ApplicationRecord
     self.etc_icons_on_homepage ||= true
   end
 
-  def generate_jwt
-    JWT.encode({ id: id, exp: 60.days.from_now.to_i }, Rails.application.credentials.secret_key_base)
+  def generate_jwt(expiry = 24.hours.from_now)
+    payload = {
+      id: id,
+      name: name,
+      full_name: full_name,
+      role: role.name,
+      institution_id: institution.id
+    }
+    JsonWebToken.encode(payload, expiry)
   end
 
 end

--- a/config/initializers/oidc.rb
+++ b/config/initializers/oidc.rb
@@ -1,0 +1,3 @@
+Rails.application.config.after_initialize do
+  OidcConfig.providers
+end

--- a/config/oidc_providers.yml
+++ b/config/oidc_providers.yml
@@ -6,7 +6,6 @@ providers:
     client_secret: <%= ENV['GOOG_CLIENT_SECRET'] %>
     redirect_uri: http://localhost:3000/auth/callback
     scopes: openid email profile
-    discovery: true
 
 # Add more providers here:
   # okta:
@@ -17,4 +16,3 @@ providers:
   #   client_secret: <%= ENV['OKTA_OIDC_CLIENT_SECRET'] %>
   #   redirect_uri: <%= ENV['OKTA_OIDC_REDIRECT_URI'] %>
   #   scopes: openid email profile
-  #   discovery: true

--- a/config/oidc_providers.yml
+++ b/config/oidc_providers.yml
@@ -1,0 +1,20 @@
+providers:
+  google-ncsu:
+    display_name: Google NCSU
+    issuer: https://accounts.google.com
+    client_id: <%= ENV['GOOG_CLIENT_ID'] %>
+    client_secret: <%= ENV['GOOG_CLIENT_SECRET'] %>
+    redirect_uri: http://localhost:3000/auth/callback
+    scopes: openid email profile
+    discovery: true
+
+# Add more providers here:
+  # okta:
+  #   display_name: Okta
+  #   icon: okta
+  #   issuer: https://<your-okta-domain>.okta.com
+  #   client_id: <%= ENV['OKTA_OIDC_CLIENT_ID'] %>
+  #   client_secret: <%= ENV['OKTA_OIDC_CLIENT_SECRET'] %>
+  #   redirect_uri: <%= ENV['OKTA_OIDC_REDIRECT_URI'] %>
+  #   scopes: openid email profile
+  #   discovery: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -218,5 +218,4 @@ Rails.application.routes.draw do
     get  "auth/providers",     to: "oidc_login#providers"
     post "auth/client-select", to: "oidc_login#client_select"
     post "auth/callback",      to: "oidc_login#callback"
-    get  "auth/callback",      to: "oidc_login#callback"  # temporary: for direct IdP redirect during testing
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -214,4 +214,9 @@ Rails.application.routes.draw do
       resources :assignments do
         resources :duties, controller: 'assignments_duties', only: [:index, :create, :destroy]
       end
+
+    get  "auth/providers",     to: "oidc_login#providers"
+    post "auth/client-select", to: "oidc_login#client_select"
+    post "auth/callback",      to: "oidc_login#callback"
+    get  "auth/callback",      to: "oidc_login#callback"  # temporary: for direct IdP redirect during testing
 end

--- a/db/migrate/20260407003623_create_auth_requests.rb
+++ b/db/migrate/20260407003623_create_auth_requests.rb
@@ -1,0 +1,13 @@
+class CreateAuthRequests < ActiveRecord::Migration[8.0]
+  def change
+    create_table :auth_requests do |t|
+      t.string :state
+      t.string :nonce
+      t.string :code_verifier
+      t.string :provider
+
+      t.timestamps
+    end
+    add_index :auth_requests, :state
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_13_064334) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_07_003623) do
   create_table "account_requests", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "username"
     t.string "full_name"
@@ -115,6 +115,16 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_13_064334) do
     t.datetime "updated_at", null: false
     t.index ["assignment_id"], name: "index_assignments_duties_on_assignment_id"
     t.index ["duty_id"], name: "index_assignments_duties_on_duty_id"
+  end
+
+  create_table "auth_requests", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "state"
+    t.string "nonce"
+    t.string "code_verifier"
+    t.string "provider"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["state"], name: "index_auth_requests_on_state"
   end
 
   create_table "bookmark_ratings", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -456,9 +466,9 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_13_064334) do
   add_foreign_key "assignments_duties", "duties"
   add_foreign_key "courses", "institutions"
   add_foreign_key "courses", "users", column: "instructor_id"
+  add_foreign_key "duties", "users", column: "instructor_id"
   add_foreign_key "invitations", "participants", column: "from_id"
   add_foreign_key "invitations", "participants", column: "to_id"
-  add_foreign_key "duties", "users", column: "instructor_id"
   add_foreign_key "items", "questionnaires"
   add_foreign_key "participants", "duties"
   add_foreign_key "participants", "join_team_requests"

--- a/db/seeds_oidc.rb
+++ b/db/seeds_oidc.rb
@@ -1,7 +1,26 @@
+# For conenience, will drop on final PR
 User.find_or_create_by!(email: "jweisz@ncsu.edu") do |user|
   user.name = "jweisz"
   user.password = "password123"
   user.full_name = "John Weisz"
+  user.institution_id = 1
+  user.role_id = 1
+end
+
+# For conenience, will drop on final PR
+User.find_or_create_by!(email: "jvargas6@ncsu.edu") do |user|
+  user.name = "jvargas6"
+  user.password = "password123"
+  user.full_name = "Jose Vargas"
+  user.institution_id = 1
+  user.role_id = 1
+end
+
+# For conenience, will drop on final PR
+User.find_or_create_by!(email: "jcmonseu@ncsu.edu") do |user|
+  user.name = "jcmonseu"
+  user.password = "password123"
+  user.full_name = "Jared Monseur"
   user.institution_id = 1
   user.role_id = 1
 end

--- a/db/seeds_oidc.rb
+++ b/db/seeds_oidc.rb
@@ -1,0 +1,7 @@
+User.find_or_create_by!(email: "jweisz@ncsu.edu") do |user|
+  user.name = "jweisz"
+  user.password = "password123"
+  user.full_name = "John Weisz"
+  user.institution_id = 1
+  user.role_id = 1
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
+  factory :auth_request do
+    state { "MyString" }
+    nonce { "MyString" }
+    code_verifier { "MyString" }
+    provider { "MyString" }
+  end
+
   factory :student_task do
     assignment { nil }
     current_stage { "MyString" }

--- a/spec/models/auth_request_spec.rb
+++ b/spec/models/auth_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe AuthRequest, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/oidc_login_spec.rb
+++ b/spec/requests/oidc_login_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe "OidcLogins", type: :request do
+  describe "GET /providers" do
+    it "returns http success" do
+      get "/oidc_login/providers"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /client_select" do
+    it "returns http success" do
+      get "/oidc_login/client_select"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /callback" do
+    it "returns http success" do
+      get "/oidc_login/callback"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end


### PR DESCRIPTION
As a developer, I want the session object returned to the frontend clearly defined and reusable by all login flows, so that the frontend can rely on a consistent response shape regardless of authentication method.

Acceptance Criteria:

Extract the JWT payload construction and token issuance logic from AuthenticationController#login and OidcLoginController#callback into a shared method on the User model (e.g. user.generate_jwt).
Define a consistent response structure (e.g. { token, user: { id, name, full_name, role, institution_id } }) and use it in both controllers.
Update the existing password login endpoint to use the shared method without changing its external response shape.
Add or update request specs for both login endpoints to assert the response structure matches.