### PR TITLE
Switch coverage reporting from Code Climate to qlty.sh

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -155,12 +155,11 @@ jobs:
           name: code-coverage-artifacts
           path: coverage/
 
-      - name: Upload code-coverage report to code-climate
-        run: |
-          export GIT_BRANCH="${GITHUB_REF/refs\/heads\//}"
-          gem install codeclimate-test-reporter
-          cc-test-reporter sum-coverage coverage/codeclimate.*.json 
-          cc-test-reporter after-build -t simplecov -r ${{ secrets.CC_TEST_REPORTER_ID }}
+      - name: Upload code-coverage report to qlty
+        uses: qltysh/qlty-action/coverage@v2
+        with:
+          token: ${{ secrets.CC_TEST_REPORTER_ID }}
+          files: coverage/coverage.json
 
   docker:
     needs: test


### PR DESCRIPTION
Code Climate's download server is dead. qlty.sh is its official successor with working infrastructure and native GitHub Action support.